### PR TITLE
Add helper scripts for processing and importing statediffed data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ docker-build:
 	docker build -t cerc-io/eth-statediff-service .
 
 .PHONY: test
-test: | $(GOOSE)
+test:
 	go test -p 1 ./pkg/... -v
 
 build:

--- a/README.md
+++ b/README.md
@@ -270,6 +270,21 @@ An example config file:
 
     Check the output logs for any rows detected with unexpected number of columns.
 
+    Example:
+
+    ```bash
+    # log
+    eth.header_cids
+    Start: Wednesday 21 September 2022 06:00:38 PM IST
+    Time taken: 00:00:05
+    End: Wednesday 21 September 2022 06:00:43 PM IST
+    Total bad rows: 1 ./check-columns/eth.header_cids.txt
+
+    # bad row output
+    # line number, num. of columns, data
+    23 17 22,xxxxxx,0x07f5ea5c94aa8dea60b28f6b6315d92f2b6d78ca4b74ea409adeb191b5a114f2,0x5918487321aa57dd0c50977856c6231e7c4ee79e95b694c7c8830227d77a1ecc,bagiacgzaa726uxeuvkg6uyfsr5vwgfozf4vw26gkjn2ouqe232yzdnnbctza,45,geth,0,0xad8fa8df61b98dbda7acd6ca76d5ce4cbba663d5f608cc940957adcdb94cee8d,0xc621412320a20b4aaff5363bdf063b9d13e394ef82e55689ab703aae5db08e26,0x71ec1c7d81269ce115be81c81f13e1cc2601c292a7f20440a77257ecfdc69940,0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347,\x2000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000,1658408419,/blocks/DMQAP5PKLSKKVDPKMCZI623DCXMS6K3NPDFEW5HKICNN5MMRWWQRJ4Q,1,0x0000000000000000000000000000000000000000
+    ```
+
 * Import data using `timescaledb-parallel-copy`:  
   (requires [`timescaledb-parallel-copy`](https://github.com/timescale/timescaledb-parallel-copy) installation; readily comes with TimescaleDB docker image)
 

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,21 +1,21 @@
-# used by the script to count rows
+# Used by the script to count rows (count-lines.sh)
 COUNT_LINES_LOG=./count-lines.log
 COUNT_LINES_INPUT_DIR=~/eth-statediff-service/output_dir
 COUNT_LINES_OUTPUT_FILE=./output-stats.txt
 
-# used by the script to dedup output files
+# Used by the script to dedup output files (dedup.sh)
 DEDUP_LOG=./dedup.log
 DEDUP_INPUT_DIR=~/eth-statediff-service/output_dir
 DEDUP_OUTPUT_DIR=~/eth-statediff-service/dedup_dir
 DEDUP_SORT_DIR=./.sort
 
-# used by the script to perform column checks
+# Used by the script to perform column checks (check-columns.sh)
 CHECK_COLUMNS_LOG=./check-columns.log
 CHECK_COLUMNS_INPUT_DIR=~/eth-statediff-service/output_dir
 CHECK_COLUMNS_INPUT_DEDUP_DIR=~/eth-statediff-service/dedup_dir
 CHECK_COLUMNS_OUTPUT_DIR=./check-columns
 
-# used by the script to import data
+# Used by the script to import data (timescaledb-import.sh)
 IMPORT_LOG=./tsdb-import.log
 IMPORT_INPUT_DIR=~/eth-statediff-service/output_dir
 IMPORT_INPUT_DEDUP_DIR=~/eth-statediff-service/dedup_dir

--- a/scripts/.sample.env
+++ b/scripts/.sample.env
@@ -1,0 +1,28 @@
+# used by the script to count rows
+COUNT_LINES_LOG=./count-lines.log
+COUNT_LINES_INPUT_DIR=~/eth-statediff-service/output_dir
+COUNT_LINES_OUTPUT_FILE=./output-stats.txt
+
+# used by the script to dedup output files
+DEDUP_LOG=./dedup.log
+DEDUP_INPUT_DIR=~/eth-statediff-service/output_dir
+DEDUP_OUTPUT_DIR=~/eth-statediff-service/dedup_dir
+DEDUP_SORT_DIR=./.sort
+
+# used by the script to perform column checks
+CHECK_COLUMNS_LOG=./check-columns.log
+CHECK_COLUMNS_INPUT_DIR=~/eth-statediff-service/output_dir
+CHECK_COLUMNS_INPUT_DEDUP_DIR=~/eth-statediff-service/dedup_dir
+CHECK_COLUMNS_OUTPUT_DIR=./check-columns
+
+# used by the script to import data
+IMPORT_LOG=./tsdb-import.log
+IMPORT_INPUT_DIR=~/eth-statediff-service/output_dir
+IMPORT_INPUT_DEDUP_DIR=~/eth-statediff-service/dedup_dir
+TIMESCALEDB_WORKERS=8
+
+DATABASE_USER=vdbm
+DATABASE_HOSTNAME=localhost
+DATABASE_PORT=8077
+DATABASE_NAME=vulcanize_testing
+DATABASE_PASSWORD=password

--- a/scripts/check-columns.sh
+++ b/scripts/check-columns.sh
@@ -11,7 +11,7 @@ ENV=$1
 echo "Using env file: ${ENV}"
 
 # read env file
-export $(grep -v '^#' ${ENV} | xargs -d '\n')
+export $(grep -v '^#' ${ENV} | xargs)
 
 # redirect stdout/stderr to a file
 exec >"${CHECK_COLUMNS_LOG}" 2>&1

--- a/scripts/check-columns.sh
+++ b/scripts/check-columns.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Requires:
+# CHECK_COLUMNS_LOG
+# CHECK_COLUMNS_INPUT_DIR
+# CHECK_COLUMNS_INPUT_DEDUP_DIR
+# CHECK_COLUMNS_OUTPUT_DIR
+
+# env file arg
+ENV=$1
+echo "Using env file: ${ENV}"
+
+# read env file
+export $(grep -v '^#' ${ENV} | xargs -d '\n')
+
+# redirect stdout/stderr to a file
+exec >${CHECK_COLUMNS_LOG} 2>&1
+
+# create output dir if not exists
+mkdir -p ${CHECK_COLUMNS_OUTPUT_DIR}
+
+start_timestamp=$(date +%s)
+
+echo "public.nodes"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/public.nodes.csv -c 5 -o ${CHECK_COLUMNS_OUTPUT_DIR}/public.nodes.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/public.nodes.txt)
+echo
+
+echo "public.blocks"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DEDUP_DIR}/deduped-public.blocks.csv -c 3 -o ${CHECK_COLUMNS_OUTPUT_DIR}/public.blocks.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/public.blocks.txt)
+echo
+
+# skipping as values include ','
+# echo "eth.access_list_elements"
+# $(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.access_list_elements.csv -c ? -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.access_list_elements.txt
+# echo
+
+echo "eth.log_cids"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.log_cids.csv -c 12 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.log_cids.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.log_cids.txt)
+echo
+
+echo "eth.state_accounts"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.state_accounts.csv -c 7 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.state_accounts.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.state_accounts.txt)
+echo
+
+echo "eth.storage_cids"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.storage_cids.csv -c 9 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.storage_cids.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.storage_cids.txt)
+echo
+
+echo "eth.uncle_cids"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.uncle_cids.csv -c 7 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.uncle_cids.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.uncle_cids.txt)
+echo
+
+echo "eth.header_cids"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.header_cids.csv -c 16 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.header_cids.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.header_cids.txt)
+echo
+
+echo "eth.receipt_cids"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.receipt_cids.csv -c 10 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.receipt_cids.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.receipt_cids.txt)
+echo
+
+echo "eth.state_cids"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.state_cids.csv -c 8 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.state_cids.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.state_cids.txt)
+echo
+
+echo "eth.transaction_cids"
+echo Start: $(date)
+$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.transaction_cids.csv -c 11 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.transaction_cids.txt
+echo End: $(date)
+echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.transaction_cids.txt)
+echo
+
+difference=$(($(date +%s)-start_timestamp))
+echo Time taken: $((${difference}/86400)):$(date -d@${difference} -u +%H:%M:%S)
+echo

--- a/scripts/check-columns.sh
+++ b/scripts/check-columns.sh
@@ -14,88 +14,45 @@ echo "Using env file: ${ENV}"
 export $(grep -v '^#' ${ENV} | xargs -d '\n')
 
 # redirect stdout/stderr to a file
-exec >${CHECK_COLUMNS_LOG} 2>&1
+exec >"${CHECK_COLUMNS_LOG}" 2>&1
 
 # create output dir if not exists
-mkdir -p ${CHECK_COLUMNS_OUTPUT_DIR}
+mkdir -p "${CHECK_COLUMNS_OUTPUT_DIR}"
 
 start_timestamp=$(date +%s)
 
-echo "public.nodes"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/public.nodes.csv -c 5 -o ${CHECK_COLUMNS_OUTPUT_DIR}/public.nodes.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/public.nodes.txt)
-echo
+declare -A expected_columns
+expected_columns=(
+  ["public.nodes"]="5"
+  ["public.blocks"]="3"
+  # ["eth.access_list_elements"]="?" # skipping as values include ','
+  ["eth.log_cids"]="12"
+  ["eth.state_accounts"]="7"
+  ["eth.storage_cids"]="9"
+  ["eth.uncle_cids"]="7"
+  ["eth.header_cids"]="16"
+  ["eth.receipt_cids"]="10"
+  ["eth.state_cids"]="8"
+  ["eth.transaction_cids"]="11"
+)
 
-echo "public.blocks"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DEDUP_DIR}/deduped-public.blocks.csv -c 3 -o ${CHECK_COLUMNS_OUTPUT_DIR}/public.blocks.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/public.blocks.txt)
-echo
+for table_name in "${!expected_columns[@]}";
+do
+  if [ "${table_name}" = "public.blocks" ];
+  then
+    command="$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DEDUP_DIR}/deduped-${table_name}.csv -c ${expected_columns[${table_name}]} -d true -o ${CHECK_COLUMNS_OUTPUT_DIR}/${table_name}.txt"
+  else
+    command="$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/${table_name}.csv -c ${expected_columns[${table_name}]} -d true -o ${CHECK_COLUMNS_OUTPUT_DIR}/${table_name}.txt"
+  fi
 
-# skipping as values include ','
-# echo "eth.access_list_elements"
-# $(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.access_list_elements.csv -c ? -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.access_list_elements.txt
-# echo
-
-echo "eth.log_cids"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.log_cids.csv -c 12 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.log_cids.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.log_cids.txt)
-echo
-
-echo "eth.state_accounts"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.state_accounts.csv -c 7 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.state_accounts.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.state_accounts.txt)
-echo
-
-echo "eth.storage_cids"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.storage_cids.csv -c 9 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.storage_cids.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.storage_cids.txt)
-echo
-
-echo "eth.uncle_cids"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.uncle_cids.csv -c 7 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.uncle_cids.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.uncle_cids.txt)
-echo
-
-echo "eth.header_cids"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.header_cids.csv -c 16 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.header_cids.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.header_cids.txt)
-echo
-
-echo "eth.receipt_cids"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.receipt_cids.csv -c 10 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.receipt_cids.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.receipt_cids.txt)
-echo
-
-echo "eth.state_cids"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.state_cids.csv -c 8 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.state_cids.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.state_cids.txt)
-echo
-
-echo "eth.transaction_cids"
-echo Start: $(date)
-$(dirname "$0")/find-bad-rows.sh -i ${CHECK_COLUMNS_INPUT_DIR}/eth.transaction_cids.csv -c 11 -o ${CHECK_COLUMNS_OUTPUT_DIR}/eth.transaction_cids.txt
-echo End: $(date)
-echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/eth.transaction_cids.txt)
-echo
+  echo "${table_name}"
+  echo Start: "$(date)"
+  eval "${command}"
+  echo End: "$(date)"
+  echo Total bad rows: $(wc -l ${CHECK_COLUMNS_OUTPUT_DIR}/${table_name}.txt)
+  echo
+done
 
 difference=$(($(date +%s)-start_timestamp))
-echo Time taken: $((${difference}/86400)):$(date -d@${difference} -u +%H:%M:%S)
+echo Time taken: $((difference/86400)):$(date -d@${difference} -u +%H:%M:%S)
 echo

--- a/scripts/count-lines.sh
+++ b/scripts/count-lines.sh
@@ -13,75 +13,34 @@ echo "Using env file: ${ENV}"
 export $(grep -v '^#' ${ENV} | xargs -d '\n')
 
 # redirect stdout/stderr to a file
-exec >${COUNT_LINES_LOG} 2>&1
+exec >"${COUNT_LINES_LOG}" 2>&1
 
 start_timestamp=$(date +%s)
 
-echo "public.nodes"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/public.nodes.csv > ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
+table_names=(
+  "public.nodes"
+  "public.blocks"
+  "eth.access_list_elements"
+  "eth.log_cids"
+  "eth.state_accounts"
+  "eth.storage_cids"
+  "eth.uncle_cids"
+  "eth.header_cids"
+  "eth.receipt_cids"
+  "eth.state_cids"
+  "eth.transaction_cids"
+)
 
-echo "public.blocks"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/public.blocks.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
+echo "Row counts:" > "${COUNT_LINES_OUTPUT_FILE}"
 
-echo "eth.access_list_elements"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/eth.access_list_elements.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
-
-echo "eth.log_cids"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/eth.log_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
-
-echo "eth.state_accounts"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/eth.state_accounts.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
-
-echo "eth.storage_cids"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/eth.storage_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
-
-echo "eth.uncle_cids"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/eth.uncle_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
-
-echo "eth.header_cids"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/eth.header_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
-
-echo "eth.receipt_cids"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/eth.receipt_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
-
-echo "eth.state_cids"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/eth.state_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
-
-echo "eth.transaction_cids"
-echo Start: $(date)
-wc -l ${COUNT_LINES_INPUT_DIR}/eth.transaction_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
-echo End: $(date)
-echo
+for table_name in "${table_names[@]}";
+do
+  echo "${table_name}";
+  echo Start: "$(date)"
+  wc -l "${COUNT_LINES_INPUT_DIR}"/"${table_name}.csv" >> "${COUNT_LINES_OUTPUT_FILE}"
+  echo End: "$(date)"
+  echo
+done
 
 difference=$(($(date +%s)-start_timestamp))
-echo Time taken: $((${difference}/86400)):$(date -d@${difference} -u +%H:%M:%S)
+echo Time taken: $((difference/86400)):$(date -d@${difference} -u +%H:%M:%S)

--- a/scripts/count-lines.sh
+++ b/scripts/count-lines.sh
@@ -10,7 +10,7 @@ ENV=$1
 echo "Using env file: ${ENV}"
 
 # read env file
-export $(grep -v '^#' ${ENV} | xargs -d '\n')
+export $(grep -v '^#' ${ENV} | xargs)
 
 # redirect stdout/stderr to a file
 exec >"${COUNT_LINES_LOG}" 2>&1

--- a/scripts/count-lines.sh
+++ b/scripts/count-lines.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Requires:
+# COUNT_LINES_LOG
+# COUNT_LINES_INPUT_DIR
+# COUNT_LINES_OUTPUT_FILE
+
+# env file arg
+ENV=$1
+echo "Using env file: ${ENV}"
+
+# read env file
+export $(grep -v '^#' ${ENV} | xargs -d '\n')
+
+# redirect stdout/stderr to a file
+exec >${COUNT_LINES_LOG} 2>&1
+
+start_timestamp=$(date +%s)
+
+echo "public.nodes"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/public.nodes.csv > ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "public.blocks"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/public.blocks.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "eth.access_list_elements"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/eth.access_list_elements.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "eth.log_cids"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/eth.log_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "eth.state_accounts"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/eth.state_accounts.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "eth.storage_cids"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/eth.storage_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "eth.uncle_cids"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/eth.uncle_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "eth.header_cids"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/eth.header_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "eth.receipt_cids"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/eth.receipt_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "eth.state_cids"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/eth.state_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+echo "eth.transaction_cids"
+echo Start: $(date)
+wc -l ${COUNT_LINES_INPUT_DIR}/eth.transaction_cids.csv >> ${COUNT_LINES_OUTPUT_FILE}
+echo End: $(date)
+echo
+
+difference=$(($(date +%s)-start_timestamp))
+echo Time taken: $((${difference}/86400)):$(date -d@${difference} -u +%H:%M:%S)

--- a/scripts/dedup.sh
+++ b/scripts/dedup.sh
@@ -30,3 +30,6 @@ echo
 
 difference=$(($(date +%s)-start_timestamp))
 echo Time taken: $((${difference}/86400)):$(date -d@${difference} -u +%H:%M:%S)
+
+# NOTE: This script currently only dedups public.blocks output file.
+# If the output contains blocks that were statediffed more than once, output files for other tables will have to be deduped as well.

--- a/scripts/dedup.sh
+++ b/scripts/dedup.sh
@@ -11,7 +11,7 @@ ENV=$1
 echo "Using env file: ${ENV}"
 
 # read env file
-export $(grep -v '^#' ${ENV} | xargs -d '\n')
+export $(grep -v '^#' ${ENV} | xargs)
 
 # redirect stdout/stderr to a file
 exec >"${DEDUP_LOG}" 2>&1

--- a/scripts/dedup.sh
+++ b/scripts/dedup.sh
@@ -14,22 +14,22 @@ echo "Using env file: ${ENV}"
 export $(grep -v '^#' ${ENV} | xargs -d '\n')
 
 # redirect stdout/stderr to a file
-exec >${DEDUP_LOG} 2>&1
+exec >"${DEDUP_LOG}" 2>&1
 
 # create output dir if not exists
-mkdir -p ${DEDUP_OUTPUT_DIR}
+mkdir -p "${DEDUP_OUTPUT_DIR}"
 
 start_timestamp=$(date +%s)
 
 echo "public.blocks"
-echo Start: $(date)
-sort -T ${DEDUP_SORT_DIR} -u ${DEDUP_INPUT_DIR}/public.blocks.csv -o ${DEDUP_OUTPUT_DIR}/deduped-public.blocks.csv
-echo End: $(date)
+echo Start: "$(date)"
+sort -T "${DEDUP_SORT_DIR}" -u "${DEDUP_INPUT_DIR}"/public.blocks.csv -o "${DEDUP_OUTPUT_DIR}"/deduped-public.blocks.csv
+echo End: "$(date)"
 echo Total deduped rows: $(wc -l ${DEDUP_OUTPUT_DIR}/deduped-public.blocks.csv)
 echo
 
 difference=$(($(date +%s)-start_timestamp))
-echo Time taken: $((${difference}/86400)):$(date -d@${difference} -u +%H:%M:%S)
+echo Time taken: $((difference/86400)):$(date -d@${difference} -u +%H:%M:%S)
 
 # NOTE: This script currently only dedups public.blocks output file.
 # If the output contains blocks that were statediffed more than once, output files for other tables will have to be deduped as well.

--- a/scripts/dedup.sh
+++ b/scripts/dedup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Requires:
+# DEDUP_LOG
+# DEDUP_INPUT_DIR
+# DEDUP_OUTPUT_DIR
+# DEDUP_SORT_DIR
+
+# env file arg
+ENV=$1
+echo "Using env file: ${ENV}"
+
+# read env file
+export $(grep -v '^#' ${ENV} | xargs -d '\n')
+
+# redirect stdout/stderr to a file
+exec >${DEDUP_LOG} 2>&1
+
+# create output dir if not exists
+mkdir -p ${DEDUP_OUTPUT_DIR}
+
+start_timestamp=$(date +%s)
+
+echo "public.blocks"
+echo Start: $(date)
+sort -T ${DEDUP_SORT_DIR} -u ${DEDUP_INPUT_DIR}/public.blocks.csv -o ${DEDUP_OUTPUT_DIR}/deduped-public.blocks.csv
+echo End: $(date)
+echo Total deduped rows: $(wc -l ${DEDUP_OUTPUT_DIR}/deduped-public.blocks.csv)
+echo
+
+difference=$(($(date +%s)-start_timestamp))
+echo Time taken: $((${difference}/86400)):$(date -d@${difference} -u +%H:%M:%S)

--- a/scripts/find-bad-rows.sh
+++ b/scripts/find-bad-rows.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# flags
+# -i <input-file>:        Input data file path
+# -c <expected-columns>:  Expected number of columns in each row of the input file
+# -o [output-file]:       Output destination file path (default: STDOUT)
+# -d [include-data]:      Whether to include the data row in output (true | false) (default: false)
+
+# eg: ./scripts/find-bad-rows.sh -i eth.state_cids.csv -c 8 -o res.txt -d true
+# output: 1 9 1500000,xxxxxxxx,0x83952d392f9b0059eea94b10d1a095eefb1943ea91595a16c6698757127d4e1c,,
+#         baglacgzasvqcntdahkxhufdnkm7a22s2eetj6mx6nzkarwxtkvy4x3bubdgq,\x0f,0,f,/blocks/,
+#         DMQJKYBGZRQDVLT2CRWVGPQNNJNCCJU7GL7G4VAI3LZVK4OL5Q2ARTI
+
+while getopts i:c:o:d: OPTION
+do
+  case "${OPTION}" in
+    i) inputFile=${OPTARG};;
+    c) expectedColumns=${OPTARG};;
+    o) outputFile=${OPTARG};;
+    d) data=${OPTARG};;
+  esac
+done
+
+timestamp=$(date +%s)
+
+# if data requested, dump row number, number of columns and the row
+if [ "${data}" = true ] ; then
+  if [ -z "${outputFile}" ]; then
+    awk -F"," "NF!=${expectedColumns} {print NR, NF, \$0}" < ${inputFile}
+  else
+    awk -F"," "NF!=${expectedColumns} {print NR, NF, \$0}" < ${inputFile} > ${outputFile}
+  fi
+# else, dump only row number, number of columns
+else
+  if [ -z "${outputFile}" ]; then
+    awk -F"," "NF!=${expectedColumns} {print NR, NF}" < ${inputFile}
+  else
+    awk -F"," "NF!=${expectedColumns} {print NR, NF}" < ${inputFile} > ${outputFile}
+  fi
+fi
+
+difference=$(($(date +%s)-timestamp))
+echo Time taken: $(date -d@${difference} -u +%H:%M:%S)

--- a/scripts/timescaledb-import.sh
+++ b/scripts/timescaledb-import.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Requires:
+# IMPORT_LOG
+# IMPORT_INPUT_DIR
+# IMPORT_INPUT_DEDUP_DIR
+# TIMESCALEDB_WORKERS
+# DATABASE_USER
+# DATABASE_HOSTNAME
+# DATABASE_PORT
+# DATABASE_NAME
+# DATABASE_PASSWORD
+
+DEFAULT_TIMESCALEDB_WORKERS=8
+
+# env file arg
+ENV=$1
+echo "Using env file: ${ENV}"
+
+# read env file
+export $(grep -v '^#' ${ENV} | xargs -d '\n')
+
+if [ "$TIMESCALEDB_WORKERS" = "" ]; then
+	TIMESCALEDB_WORKERS=$DEFAULT_TIMESCALEDB_WORKERS
+fi
+
+# redirect stdout/stderr to a file
+exec >${IMPORT_LOG} 2>&1
+
+start_timestamp=$(date +%s)
+
+echo "public.nodes"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema public --table nodes --file ${IMPORT_INPUT_DIR}/public.nodes.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "public.blocks"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema public --table blocks --file ${IMPORT_INPUT_DEDUP_DIR}/deduped-public.blocks.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "eth.access_list_elements"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table access_list_elements --file ${IMPORT_INPUT_DIR}/eth.access_list_elements.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "eth.log_cids"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table log_cids --file ${IMPORT_INPUT_DIR}/eth.log_cids.csv --copy-options "FORCE NOT NULL topic0, topic1, topic2, topic3 CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "eth.state_accounts"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table state_accounts --file ${IMPORT_INPUT_DIR}/eth.state_accounts.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "eth.storage_cids"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table storage_cids --file ${IMPORT_INPUT_DIR}/eth.storage_cids.csv --copy-options "FORCE NOT NULL storage_leaf_key CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "eth.uncle_cids"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table uncle_cids --file ${IMPORT_INPUT_DIR}/eth.uncle_cids.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "eth.header_cids"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table header_cids --file ${IMPORT_INPUT_DIR}/eth.header_cids.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "eth.receipt_cids"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table receipt_cids --file ${IMPORT_INPUT_DIR}/eth.receipt_cids.csv --copy-options "FORCE NOT NULL post_state, contract, contract_hash CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "eth.state_cids"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table state_cids --file ${IMPORT_INPUT_DIR}/eth.state_cids.csv --copy-options "FORCE NOT NULL state_leaf_key CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+echo "eth.transaction_cids"
+echo Start: $(date)
+timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table transaction_cids --file ${IMPORT_INPUT_DIR}/eth.transaction_cids.csv --copy-options "FORCE NOT NULL dst CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
+echo End: $(date)
+echo
+
+difference=$(($(date +%s)-start_timestamp))
+echo Time taken: $((${difference}/86400)):$(date -d@${difference} -u +%H:%M:%S)
+echo

--- a/scripts/timescaledb-import.sh
+++ b/scripts/timescaledb-import.sh
@@ -18,7 +18,7 @@ ENV=$1
 echo "Using env file: ${ENV}"
 
 # read env file
-export $(grep -v '^#' ${ENV} | xargs -d '\n')
+export $(grep -v '^#' ${ENV} | xargs)
 
 if [ "$TIMESCALEDB_WORKERS" = "" ]; then
 	TIMESCALEDB_WORKERS=$DEFAULT_TIMESCALEDB_WORKERS
@@ -51,9 +51,9 @@ do
 
 	if [ "${arr[0]}.${arr[1]}" = "public.blocks" ];
 	then
-		copy_command="/home/prathamesh/go/bin/timescaledb-parallel-copy --connection \"host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable\" --db-name ${DATABASE_NAME} --schema ${arr[0]} --table ${arr[1]} --file ${IMPORT_INPUT_DEDUP_DIR}/deduped-${arr[0]}.${arr[1]}.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s"
+		copy_command="timescaledb-parallel-copy --connection \"host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable\" --db-name ${DATABASE_NAME} --schema ${arr[0]} --table ${arr[1]} --file ${IMPORT_INPUT_DEDUP_DIR}/deduped-${arr[0]}.${arr[1]}.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s"
 	else
-		copy_command="/home/prathamesh/go/bin/timescaledb-parallel-copy --connection \"host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable\" --db-name ${DATABASE_NAME} --schema ${arr[0]} --table ${arr[1]} --file ${IMPORT_INPUT_DIR}/${arr[0]}.${arr[1]}.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s"
+		copy_command="timescaledb-parallel-copy --connection \"host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable\" --db-name ${DATABASE_NAME} --schema ${arr[0]} --table ${arr[1]} --file ${IMPORT_INPUT_DIR}/${arr[0]}.${arr[1]}.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s"
 	fi
 
 	if [ "${arr[2]}" != "" ];

--- a/scripts/timescaledb-import.sh
+++ b/scripts/timescaledb-import.sh
@@ -25,76 +25,51 @@ if [ "$TIMESCALEDB_WORKERS" = "" ]; then
 fi
 
 # redirect stdout/stderr to a file
-exec >${IMPORT_LOG} 2>&1
+exec >"${IMPORT_LOG}" 2>&1
 
 start_timestamp=$(date +%s)
 
-echo "public.nodes"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema public --table nodes --file ${IMPORT_INPUT_DIR}/public.nodes.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
+declare -a tables
+# schema-table-copyOptions
+tables=(
+  "public-nodes"
+  "public-blocks"
+  "eth-access_list_elements"
+  "eth-log_cids-FORCE NOT NULL topic0, topic1, topic2, topic3 CSV"
+  "eth-state_accounts"
+  "eth-storage_cids-FORCE NOT NULL storage_leaf_key CSV"
+  "eth-uncle_cids"
+  "eth-header_cids"
+  "eth-receipt_cids-FORCE NOT NULL post_state, contract, contract_hash CSV"
+  "eth-state_cids-FORCE NOT NULL state_leaf_key CSV"
+  "eth-transaction_cids-FORCE NOT NULL dst CSV"
+)
 
-echo "public.blocks"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema public --table blocks --file ${IMPORT_INPUT_DEDUP_DIR}/deduped-public.blocks.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
+for elem in "${tables[@]}";
+do
+	IFS='-' read -a arr <<< "${elem}"
 
-echo "eth.access_list_elements"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table access_list_elements --file ${IMPORT_INPUT_DIR}/eth.access_list_elements.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
+	if [ "${arr[0]}.${arr[1]}" = "public.blocks" ];
+	then
+		copy_command="/home/prathamesh/go/bin/timescaledb-parallel-copy --connection \"host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable\" --db-name ${DATABASE_NAME} --schema ${arr[0]} --table ${arr[1]} --file ${IMPORT_INPUT_DEDUP_DIR}/deduped-${arr[0]}.${arr[1]}.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s"
+	else
+		copy_command="/home/prathamesh/go/bin/timescaledb-parallel-copy --connection \"host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable\" --db-name ${DATABASE_NAME} --schema ${arr[0]} --table ${arr[1]} --file ${IMPORT_INPUT_DIR}/${arr[0]}.${arr[1]}.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s"
+	fi
 
-echo "eth.log_cids"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table log_cids --file ${IMPORT_INPUT_DIR}/eth.log_cids.csv --copy-options "FORCE NOT NULL topic0, topic1, topic2, topic3 CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
+	if [ "${arr[2]}" != "" ];
+	then
+		copy_with_options="${copy_command} --copy-options \"${arr[2]}\""
+	else
+		copy_with_options=${copy_command}
+	fi
 
-echo "eth.state_accounts"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table state_accounts --file ${IMPORT_INPUT_DIR}/eth.state_accounts.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
-
-echo "eth.storage_cids"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table storage_cids --file ${IMPORT_INPUT_DIR}/eth.storage_cids.csv --copy-options "FORCE NOT NULL storage_leaf_key CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
-
-echo "eth.uncle_cids"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table uncle_cids --file ${IMPORT_INPUT_DIR}/eth.uncle_cids.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
-
-echo "eth.header_cids"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table header_cids --file ${IMPORT_INPUT_DIR}/eth.header_cids.csv --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
-
-echo "eth.receipt_cids"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table receipt_cids --file ${IMPORT_INPUT_DIR}/eth.receipt_cids.csv --copy-options "FORCE NOT NULL post_state, contract, contract_hash CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
-
-echo "eth.state_cids"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table state_cids --file ${IMPORT_INPUT_DIR}/eth.state_cids.csv --copy-options "FORCE NOT NULL state_leaf_key CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
-
-echo "eth.transaction_cids"
-echo Start: $(date)
-timescaledb-parallel-copy --connection "host=${DATABASE_HOSTNAME} port=${DATABASE_PORT} user=${DATABASE_USER} password=${DATABASE_PASSWORD} sslmode=disable" --db-name ${DATABASE_NAME} --schema eth --table transaction_cids --file ${IMPORT_INPUT_DIR}/eth.transaction_cids.csv --copy-options "FORCE NOT NULL dst CSV" --workers ${TIMESCALEDB_WORKERS} --reporting-period 300s
-echo End: $(date)
-echo
+	echo "${arr[0]}.${arr[1]}"
+	echo Start: "$(date)"
+	eval "${copy_with_options}"
+	echo End: "$(date)"
+	echo
+done
 
 difference=$(($(date +%s)-start_timestamp))
-echo Time taken: $((${difference}/86400)):$(date -d@${difference} -u +%H:%M:%S)
+echo Time taken: $((difference/86400)):$(date -d@${difference} -u +%H:%M:%S)
 echo


### PR DESCRIPTION
Part of https://github.com/cerc-io/eth-statediff-service/issues/100

- Add helper scripts for processing and importing statediffed data (CSV files) using `timescaledb-parallel-copy`