### PR TITLE
remove flooring of segment size

### DIFF
--- a/pkg/service.go
+++ b/pkg/service.go
@@ -125,11 +125,6 @@ func (sds *Service) Run(rngs []RangeRequest, parallel bool) error {
 			chunkSize := (preRun.Stop - preRun.Start) / uint64(sds.workers)
 			logrus.Infof("parallel processing prerun range (%d, %d) (%d blocks) divided into %d sized chunks with %d workers", preRun.Start, preRun.Stop,
 				preRun.Stop-preRun.Start+1, chunkSize, sds.workers)
-			// Sanity floor the chunk size
-			if chunkSize < 100 {
-				chunkSize = 100
-				logrus.Infof("Computed range chunk size for each worker is too small, defaulting to 100")
-			}
 			wg := new(sync.WaitGroup)
 			for i := 0; i < int(sds.workers); i++ {
 				blockRange := RangeRequest{


### PR DESCRIPTION
Fix a bug that only presented itself when working with small segments/ranges. Flooring the segment size to 100 caused the process to work outside the designated range when `100 x numOfWorkers > rangeSize`. 

Thanks @srwadleigh for identifying this!