### PR TITLE
revert to using os.Interrupt

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -22,7 +22,6 @@ import (
 	"os/signal"
 	"runtime"
 	"sync"
-	"syscall"
 
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/sirupsen/logrus"
@@ -114,7 +113,7 @@ func serve() {
 
 	// clean shutdown
 	shutdown := make(chan os.Signal)
-	signal.Notify(shutdown, syscall.SIGINT)
+	signal.Notify(shutdown, os.Interrupt)
 	<-shutdown
 	logWithCommand.Info("Received interrupt signal, shutting down")
 	statediffService.Stop()


### PR DESCRIPTION
Not needed, but my IDE had tricked me into thinking we need to use `syscall.SIGINT` when we can still use `os.Interrupt` and since we already import `os` and not `syscall` this is cleaner imo.