### PR TITLE
Output metadata on prerun.

### DIFF
--- a/startup_script.sh
+++ b/startup_script.sh
@@ -7,6 +7,7 @@ set +x
 test "$VDB_COMMAND"
 set +e
 
+
 # docker must be run in privilaged mode for mounts to work
 echo "Setting up /app/geth-rw overlayed /app/geth-ro"
 mkdir -p /tmp/overlay && \
@@ -16,5 +17,25 @@ mkdir -p /tmp/overlay/work && \
 mkdir -p /app/geth-rw && \
 sudo mount -t overlay overlay -o lowerdir=/app/geth-ro,upperdir=/tmp/overlay/upper,workdir=/tmp/overlay/work /app/geth-rw && \
 
+START_TIME=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
 echo "Running the statediff service" && \
-sudo ./eth-statediff-service "$VDB_COMMAND" --config=config.toml
+sudo -E ./eth-statediff-service "$VDB_COMMAND" --config=config.toml $*
+rc=$?
+
+STOP_TIME=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+if [ $rc -eq 0 ] && [ "$PRERUN_ONLY" == "true" ] && [ ! -z "$PRERUN_RANGE_START" ] && [ ! -z "$PRERUN_RANGE_STOP" ] && [ ! -z "$DATABASE_FILE_CSV_DIR" ] && [ "$DATABASE_FILE_MODE" == "csv" ]; then
+  cat >"$DATABASE_FILE_CSV_DIR/metadata.json" <<EOF
+{
+  "range": { "start": $PRERUN_RANGE_START, "stop": $PRERUN_RANGE_STOP },
+  "nodeId": "$ETH_NODE_ID",
+  "genesisBlock": "$ETH_GENESIS_BLOCK",
+  "networkId": "$ETH_NETWORK_ID",
+  "chainId": "$ETH_CHAIN_ID",
+  "time": { "start": "$START_TIME", "stop": "$STOP_TIME" }
+}
+EOF
+fi
+
+exit $rc


### PR DESCRIPTION
Update the Docker script to output metadata along with the CSV when doing a "prerun" only.

This works with https://github.com/cerc-io/chain-chunker for batch statediffing.